### PR TITLE
Start basic test suite, includes some memleaks + a failure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,11 +27,12 @@ missing
 mkinstalldirs
 modules
 run-tests.php
-tests/*/*.diff
-tests/*/*.out
-tests/*/*.php
-tests/*/*.exp
-tests/*/*.log
-tests/*/*.sh
+tests/*.diff
+tests/*.out
+tests/*.php
+tests/*.exp
+tests/*.log
+tests/*.sh
+!tests/helpers.php
 
 jta

--- a/tests/001.phpt
+++ b/tests/001.phpt
@@ -3,19 +3,8 @@ Check for amf presence
 --SKIPIF--
 <?php if (!extension_loaded("amf")) print "skip"; ?>
 --FILE--
-<?php 
+<?php
 echo "amf extension is available";
-/*
-	you can add regression tests for your extension here
-
-  the output of your test code has to be equal to the
-  text in the --EXPECT-- section below for the tests
-  to pass, differences between the output and the
-  expected text are interpreted as failure
-
-	see php5/README.TESTING for further information on
-  writing regression tests
-*/
 ?>
 --EXPECT--
 amf extension is available

--- a/tests/002.phpt
+++ b/tests/002.phpt
@@ -1,0 +1,26 @@
+--TEST--
+Bool+null encode/decode
+--SKIPIF--
+<?php if (!extension_loaded("amf")) print "skip"; ?>
+--FILE--
+<?php
+include 'helpers.php';
+
+encodeAndDecode(true);
+encodeAndDecode(false);
+encodeAndDecode(null);
+
+?>
+--EXPECT--
+string(2) "03"
+bool(true)
+OK
+
+string(2) "02"
+bool(false)
+OK
+
+string(2) "01"
+NULL
+OK
+

--- a/tests/003.phpt
+++ b/tests/003.phpt
@@ -1,0 +1,23 @@
+--TEST--
+Number encode/decode
+--SKIPIF--
+<?php if (!extension_loaded("amf")) print "skip"; ?>
+--FILE--
+<?php
+include 'helpers.php';
+
+encodeAndDecode(0);
+encodeAndDecode(10);
+encodeAndDecode(5000000000);
+
+?>
+--EXPECT--
+string(4) "0400"
+int(0)
+OK
+
+string(4) "040a"
+int(10)
+OK
+
+TODO test failure Sean-Der

--- a/tests/004.phpt
+++ b/tests/004.phpt
@@ -1,0 +1,26 @@
+--TEST--
+String encode/decode
+--SKIPIF--
+<?php if (!extension_loaded("amf")) print "skip"; ?>
+--FILE--
+<?php
+include 'helpers.php';
+
+encodeAndDecode('');
+encodeAndDecode('testing');
+encodeAndDecode('testing $123');
+
+?>
+--EXPECT--
+string(4) "0601"
+string(0) ""
+OK
+
+string(18) "060f74657374696e67"
+string(7) "testing"
+OK
+
+string(28) "061974657374696e672024313233"
+string(12) "testing $123"
+OK
+

--- a/tests/005.phpt
+++ b/tests/005.phpt
@@ -1,0 +1,54 @@
+--TEST--
+Array encode/decode
+--SKIPIF--
+<?php if (!extension_loaded("amf")) print "skip"; ?>
+--FILE--
+<?php
+include 'helpers.php';
+
+encodeAndDecode([]);
+encodeAndDecode([true]);
+encodeAndDecode([1, true, 'string', null]);
+encodeAndDecode(['a' => 1, 'b' => 3]);
+encodeAndDecode(['a' => 1, 5, 6]);
+
+?>
+--EXPECT--
+string(6) "090101"
+array(0) {
+}
+OK
+
+string(8) "09030103"
+array(1) {
+  [0]=>
+  bool(true)
+}
+OK
+
+string(30) "090901040103060d737472696e6701"
+array(4) {
+  [0]=>
+  int(1)
+  [1]=>
+  bool(true)
+  [2]=>
+  string(6) "string"
+  [3]=>
+  NULL
+}
+OK
+
+TODO encode/decode failed --Sean-Der
+
+string(22) "0905036104010104050406"
+array(3) {
+  ["a"]=>
+  int(1)
+  [0]=>
+  int(5)
+  [1]=>
+  int(6)
+}
+OK
+

--- a/tests/helpers.php
+++ b/tests/helpers.php
@@ -1,0 +1,17 @@
+<?php
+
+function encodeAndDecode($input) {
+  $encoded = amf_encode($input);
+  var_dump(bin2hex($encoded));
+
+  $decoded = amf_decode($encoded);
+  if ($input === $decoded) {
+    var_dump($input);
+    echo "OK\n\n";
+  } else {
+    var_dump($input);
+    echo "Encode/decode created\n";
+    var_dump($decoded);
+    echo "FAILED\n\n";
+  }
+}


### PR DESCRIPTION
Hey! This creates a basic test suite. If you run `make test` it will run all the *.phpt files in that directory

Currently 003.phpt + 005.phpt fail, I will submit a PR fixing those fails!

Feel free to beef up the tests like you said with real data, something like a `tests/data` and compare them etc...

When a test fails it will spit out some helpful files 
- `.out` to show you the stdout of the test
- `.sh + .php` so you can quickly debug the test
- `.diff` to show you the difference between what the stdout should be
